### PR TITLE
feat: brand spinner for all loading states

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { onMounted, computed, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import AppHeader from '@/components/common/AppHeader.vue';
 import AppSidebar from '@/components/common/AppSidebar.vue';
+import BeanieSpinner from '@/components/ui/BeanieSpinner.vue';
 import CelebrationOverlay from '@/components/ui/CelebrationOverlay.vue';
 import { updateRatesIfStale } from '@/services/exchangeRate';
 import { processRecurringItems } from '@/services/recurring/recurringProcessor';
@@ -277,13 +278,7 @@ onMounted(async () => {
         v-if="isInitializing"
         class="fixed inset-0 z-[300] flex flex-col items-center justify-center bg-[#FDFBF9] dark:bg-[#1a252f]"
       >
-        <img
-          src="/brand/beanies_spinner_transparent_192x192.png"
-          alt="Loading"
-          class="h-24 w-24 animate-spin"
-          style="animation-duration: 1.8s"
-        />
-        <p class="mt-4 text-sm text-gray-400 dark:text-gray-500">counting beans...</p>
+        <BeanieSpinner size="xl" label />
       </div>
     </Transition>
 

--- a/src/components/settings/ExchangeRateSettings.vue
+++ b/src/components/settings/ExchangeRateSettings.vue
@@ -67,22 +67,12 @@ function formatRate(rate: number): string {
         </div>
         <BaseButton variant="secondary" size="sm" :disabled="isUpdating" @click="handleRefresh">
           <span v-if="isUpdating" class="flex items-center gap-2">
-            <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24">
-              <circle
-                class="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-                fill="none"
-              />
-              <path
-                class="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
+            <img
+              src="/brand/beanies_spinner_transparent_192x192.png"
+              alt=""
+              class="h-4 w-4 animate-spin"
+              style="animation-duration: 1.8s"
+            />
             Updating...
           </span>
           <span v-else>Refresh Rates</span>

--- a/src/components/ui/BaseButton.vue
+++ b/src/components/ui/BaseButton.vue
@@ -59,20 +59,13 @@ function handleClick(event: MouseEvent) {
 
 <template>
   <button :type="type" :class="classes" :disabled="disabled || loading" @click="handleClick">
-    <svg
+    <img
       v-if="loading"
+      src="/brand/beanies_spinner_transparent_192x192.png"
+      alt=""
       class="mr-2 -ml-1 h-4 w-4 animate-spin"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-      <path
-        class="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      />
-    </svg>
+      style="animation-duration: 1.8s"
+    />
     <slot />
   </button>
 </template>

--- a/src/components/ui/BeanieSpinner.vue
+++ b/src/components/ui/BeanieSpinner.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useTranslation } from '@/composables/useTranslation';
+
+type SpinnerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+interface Props {
+  size?: SpinnerSize;
+  label?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 'md',
+  label: false,
+});
+
+const { t } = useTranslation();
+
+const sizeClasses = computed(() => {
+  const sizes: Record<SpinnerSize, string> = {
+    xs: 'h-4 w-4',
+    sm: 'h-6 w-6',
+    md: 'h-10 w-10',
+    lg: 'h-16 w-16',
+    xl: 'h-24 w-24',
+  };
+  return sizes[props.size];
+});
+
+const labelClasses = computed(() => {
+  const sizes: Record<SpinnerSize, string> = {
+    xs: 'text-xs',
+    sm: 'text-xs',
+    md: 'text-sm',
+    lg: 'text-sm',
+    xl: 'text-base',
+  };
+  return sizes[props.size];
+});
+</script>
+
+<template>
+  <div class="inline-flex flex-col items-center gap-2">
+    <img
+      src="/brand/beanies_spinner_transparent_192x192.png"
+      :alt="t('action.loading')"
+      :class="sizeClasses"
+      class="animate-spin"
+      style="animation-duration: 1.8s"
+    />
+    <p v-if="label" :class="labelClasses" class="text-[#2C3E50]/50 dark:text-[#BDC3C7]/50">
+      {{ t('action.loading') }}
+    </p>
+  </div>
+</template>

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { default as BeanieIcon } from './BeanieIcon.vue';
+export { default as BeanieSpinner } from './BeanieSpinner.vue';
 export { default as BaseButton } from './BaseButton.vue';
 export { default as CelebrationOverlay } from './CelebrationOverlay.vue';
 export { default as BaseCard } from './BaseCard.vue';

--- a/src/pages/MagicLinkCallbackPage.vue
+++ b/src/pages/MagicLinkCallbackPage.vue
@@ -2,6 +2,7 @@
 import { onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import BaseCard from '@/components/ui/BaseCard.vue';
+import BeanieSpinner from '@/components/ui/BeanieSpinner.vue';
 import { isCognitoConfigured } from '@/config/cognito';
 import * as cognitoService from '@/services/auth/cognitoService';
 import * as tokenManager from '@/services/auth/tokenManager';
@@ -94,9 +95,7 @@ function goToLogin() {
   <div class="flex min-h-screen items-center justify-center bg-gray-50 p-4 dark:bg-slate-900">
     <BaseCard class="w-full max-w-md text-center">
       <div v-if="status === 'verifying'" class="py-8">
-        <div
-          class="border-sky-silk-100 border-t-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4"
-        ></div>
+        <BeanieSpinner size="md" class="mx-auto mb-4" />
         <p class="text-gray-600 dark:text-gray-400">Verifying your magic link...</p>
       </div>
 


### PR DESCRIPTION
## Summary
- Create reusable `BeanieSpinner` component with size variants (xs/sm/md/lg/xl) and optional "counting beans..." label
- Replace generic SVG spinners across the app with the brand beanie spinner image
- All spinners use consistent 1.8s animation duration

### Files changed
- **New:** `src/components/ui/BeanieSpinner.vue`
- `src/components/ui/index.ts` — export BeanieSpinner
- `src/App.vue` — use BeanieSpinner for initial load
- `src/components/ui/BaseButton.vue` — brand spinner for button loading state
- `src/pages/MagicLinkCallbackPage.vue` — brand spinner for verification
- `src/components/settings/ExchangeRateSettings.vue` — brand spinner for rate refresh

Closes #49

## Test plan
- [ ] App initial load shows beanie spinner with "counting beans..." text
- [ ] Button loading states show small beanie spinner
- [ ] Exchange rate refresh shows beanie spinner
- [ ] Magic link callback page shows beanie spinner
- [ ] Dark mode renders correctly for all spinner contexts
- [ ] Spinner animation is smooth at 1.8s duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)