### PR TITLE
feat(crypto): add family key encryption, wrapping, and invite link service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chart.js": "^4.5.1",
         "idb": "^8.0.3",
         "pinia": "^3.0.4",
+        "qrcode": "^1.5.4",
         "vue": "^3.5.24",
         "vue-chartjs": "^5.3.3",
         "vue-router": "^4.6.4"
@@ -23,6 +24,7 @@
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.2.1",
         "@types/node": "^25.3.0",
+        "@types/qrcode": "^1.5.6",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
@@ -3800,6 +3802,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -4564,7 +4576,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5080,6 +5091,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
@@ -5198,11 +5218,85 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5215,7 +5309,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colord": {
@@ -5473,6 +5566,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5535,6 +5637,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -7003,6 +7111,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -9402,6 +9519,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -9452,7 +9578,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9598,6 +9723,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9884,6 +10018,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10024,6 +10175,15 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -10033,6 +10193,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10302,6 +10468,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -12449,6 +12621,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -13138,6 +13316,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13159,6 +13343,143 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chart.js": "^4.5.1",
     "idb": "^8.0.3",
     "pinia": "^3.0.4",
+    "qrcode": "^1.5.4",
     "vue": "^3.5.24",
     "vue-chartjs": "^5.3.3",
     "vue-router": "^4.6.4"
@@ -50,6 +51,7 @@
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/node": "^25.3.0",
+    "@types/qrcode": "^1.5.6",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",

--- a/src/services/crypto/__tests__/familyKeyService.test.ts
+++ b/src/services/crypto/__tests__/familyKeyService.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import {
+  generateFamilyKey,
+  exportFamilyKey,
+  importFamilyKey,
+  deriveMemberKey,
+  wrapFamilyKey,
+  unwrapFamilyKey,
+  encryptPayload,
+  decryptPayload,
+  SALT_LENGTH,
+} from '../familyKeyService';
+
+describe('familyKeyService', () => {
+  // ── Key generation ──────────────────────────────────────────────
+
+  describe('generateFamilyKey', () => {
+    it('generates an AES-GCM key', async () => {
+      const key = await generateFamilyKey();
+      expect(key.type).toBe('secret');
+      expect(key.algorithm).toMatchObject({ name: 'AES-GCM', length: 256 });
+    });
+
+    it('generates an extractable key', async () => {
+      const key = await generateFamilyKey();
+      expect(key.extractable).toBe(true);
+    });
+
+    it('has encrypt and decrypt usages', async () => {
+      const key = await generateFamilyKey();
+      expect(key.usages).toContain('encrypt');
+      expect(key.usages).toContain('decrypt');
+    });
+
+    it('generates unique keys', async () => {
+      const key1 = await generateFamilyKey();
+      const key2 = await generateFamilyKey();
+      const raw1 = await exportFamilyKey(key1);
+      const raw2 = await exportFamilyKey(key2);
+      expect(raw1).not.toEqual(raw2);
+    });
+  });
+
+  // ── Export / import round-trip ──────────────────────────────────
+
+  describe('exportFamilyKey / importFamilyKey', () => {
+    it('round-trips through export and import', async () => {
+      const original = await generateFamilyKey();
+      const raw = await exportFamilyKey(original);
+      expect(raw).toBeInstanceOf(Uint8Array);
+      expect(raw.byteLength).toBe(32); // 256 bits
+
+      const imported = await importFamilyKey(raw);
+      expect(imported.extractable).toBe(true);
+
+      // Prove functional equivalence: encrypt with original, decrypt with imported
+      const plaintext = new TextEncoder().encode('hello family');
+      const encrypted = await encryptPayload(original, plaintext);
+      const decrypted = await decryptPayload(imported, encrypted);
+      expect(decrypted).toEqual(plaintext);
+    });
+  });
+
+  // ── deriveMemberKey ─────────────────────────────────────────────
+
+  describe('deriveMemberKey', () => {
+    it('produces deterministic keys for same password + salt', async () => {
+      const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+      const key1 = await deriveMemberKey('password123', salt);
+      const key2 = await deriveMemberKey('password123', salt);
+      // Cannot compare CryptoKeys directly, but wrapping the same FK should produce
+      // identical output
+      const fk = await generateFamilyKey();
+      const wrapped1 = await wrapFamilyKey(fk, key1);
+      const wrapped2 = await wrapFamilyKey(fk, key2);
+      expect(wrapped1).toBe(wrapped2);
+    });
+
+    it('produces different keys for different passwords', async () => {
+      const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+      const fk = await generateFamilyKey();
+      const key1 = await deriveMemberKey('password-A', salt);
+      const key2 = await deriveMemberKey('password-B', salt);
+      const wrapped1 = await wrapFamilyKey(fk, key1);
+      const wrapped2 = await wrapFamilyKey(fk, key2);
+      expect(wrapped1).not.toBe(wrapped2);
+    });
+
+    it('produces an AES-KW key', async () => {
+      const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+      const key = await deriveMemberKey('test', salt);
+      expect(key.algorithm).toMatchObject({ name: 'AES-KW', length: 256 });
+      expect(key.usages).toContain('wrapKey');
+      expect(key.usages).toContain('unwrapKey');
+    });
+  });
+
+  // ── Wrap / unwrap round-trip ────────────────────────────────────
+
+  describe('wrapFamilyKey / unwrapFamilyKey', () => {
+    it('round-trips the family key', async () => {
+      const fk = await generateFamilyKey();
+      const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+      const wrappingKey = await deriveMemberKey('my-password', salt);
+
+      const wrapped = await wrapFamilyKey(fk, wrappingKey);
+      expect(typeof wrapped).toBe('string');
+      expect(wrapped.length).toBeGreaterThan(0);
+
+      const unwrapped = await unwrapFamilyKey(wrapped, wrappingKey);
+      expect(unwrapped.extractable).toBe(true);
+
+      // Functional equivalence
+      const rawOriginal = await exportFamilyKey(fk);
+      const rawUnwrapped = await exportFamilyKey(unwrapped);
+      expect(rawUnwrapped).toEqual(rawOriginal);
+    });
+
+    it('rejects wrong wrapping key', async () => {
+      const fk = await generateFamilyKey();
+      const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+      const correctKey = await deriveMemberKey('correct-password', salt);
+      const wrongKey = await deriveMemberKey('wrong-password', salt);
+
+      const wrapped = await wrapFamilyKey(fk, correctKey);
+
+      await expect(unwrapFamilyKey(wrapped, wrongKey)).rejects.toThrow();
+    });
+  });
+
+  // ── Payload encryption ──────────────────────────────────────────
+
+  describe('encryptPayload / decryptPayload', () => {
+    it('round-trips binary data', async () => {
+      const fk = await generateFamilyKey();
+      const plaintext = new Uint8Array([1, 2, 3, 4, 5, 100, 200, 255]);
+
+      const encrypted = await encryptPayload(fk, plaintext);
+      expect(encrypted).toBeInstanceOf(Uint8Array);
+      // Encrypted should be larger than plaintext (IV + ciphertext + auth tag)
+      expect(encrypted.byteLength).toBeGreaterThan(plaintext.byteLength);
+
+      const decrypted = await decryptPayload(fk, encrypted);
+      expect(decrypted).toEqual(plaintext);
+    });
+
+    it('handles empty payload', async () => {
+      const fk = await generateFamilyKey();
+      const empty = new Uint8Array(0);
+
+      const encrypted = await encryptPayload(fk, empty);
+      const decrypted = await decryptPayload(fk, encrypted);
+      expect(decrypted).toEqual(empty);
+    });
+
+    it('handles large payload', async () => {
+      const fk = await generateFamilyKey();
+      const large = new Uint8Array(100_000);
+      // getRandomValues has a 65536 byte limit, so fill in chunks
+      for (let i = 0; i < large.length; i += 65536) {
+        const chunk = large.subarray(i, Math.min(i + 65536, large.length));
+        crypto.getRandomValues(chunk);
+      }
+
+      const encrypted = await encryptPayload(fk, large);
+      const decrypted = await decryptPayload(fk, encrypted);
+      expect(decrypted).toEqual(large);
+    });
+
+    it('rejects wrong key', async () => {
+      const fk1 = await generateFamilyKey();
+      const fk2 = await generateFamilyKey();
+      const plaintext = new TextEncoder().encode('secret data');
+
+      const encrypted = await encryptPayload(fk1, plaintext);
+
+      await expect(decryptPayload(fk2, encrypted)).rejects.toThrow();
+    });
+
+    it('produces different ciphertexts for same plaintext (random IV)', async () => {
+      const fk = await generateFamilyKey();
+      const plaintext = new TextEncoder().encode('same input');
+
+      const encrypted1 = await encryptPayload(fk, plaintext);
+      const encrypted2 = await encryptPayload(fk, plaintext);
+      expect(encrypted1).not.toEqual(encrypted2);
+    });
+  });
+});

--- a/src/services/crypto/__tests__/inviteService.test.ts
+++ b/src/services/crypto/__tests__/inviteService.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  generateInviteToken,
+  createInvitePackage,
+  redeemInviteToken,
+  hashInviteToken,
+  buildInviteLink,
+  isInviteExpired,
+} from '../inviteService';
+import { generateFamilyKey, exportFamilyKey } from '../familyKeyService';
+
+describe('inviteService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── Token generation ────────────────────────────────────────────
+
+  describe('generateInviteToken', () => {
+    it('returns a base64url string of ~43 chars', () => {
+      const token = generateInviteToken();
+      expect(typeof token).toBe('string');
+      expect(token.length).toBe(43); // 32 bytes → 43 base64url chars (no padding)
+    });
+
+    it('produces URL-safe characters only', () => {
+      const token = generateInviteToken();
+      expect(token).not.toMatch(/[+/=]/);
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('generates unique tokens', () => {
+      const tokens = new Set(Array.from({ length: 20 }, () => generateInviteToken()));
+      expect(tokens.size).toBe(20);
+    });
+  });
+
+  // ── Create / redeem round-trip ──────────────────────────────────
+
+  describe('createInvitePackage / redeemInviteToken', () => {
+    it('round-trips the family key', async () => {
+      const fk = await generateFamilyKey();
+      const token = generateInviteToken();
+
+      const pkg = await createInvitePackage(fk, token);
+      expect(pkg.salt).toBeTruthy();
+      expect(pkg.wrapped).toBeTruthy();
+      expect(pkg.expiresAt).toBeTruthy();
+
+      const recovered = await redeemInviteToken(pkg.wrapped, pkg.salt, token);
+      const rawOriginal = await exportFamilyKey(fk);
+      const rawRecovered = await exportFamilyKey(recovered);
+      expect(rawRecovered).toEqual(rawOriginal);
+    });
+
+    it('rejects wrong token', async () => {
+      const fk = await generateFamilyKey();
+      const correctToken = generateInviteToken();
+      const wrongToken = generateInviteToken();
+
+      const pkg = await createInvitePackage(fk, correctToken);
+
+      await expect(redeemInviteToken(pkg.wrapped, pkg.salt, wrongToken)).rejects.toThrow();
+    });
+
+    it('sets expiry 24h in the future', async () => {
+      const fk = await generateFamilyKey();
+      const token = generateInviteToken();
+
+      const before = Date.now();
+      const pkg = await createInvitePackage(fk, token);
+      const after = Date.now();
+
+      const expiryMs = new Date(pkg.expiresAt).getTime();
+      const twentyFourHours = 24 * 60 * 60 * 1000;
+      expect(expiryMs).toBeGreaterThanOrEqual(before + twentyFourHours);
+      expect(expiryMs).toBeLessThanOrEqual(after + twentyFourHours);
+    });
+  });
+
+  // ── Token hashing ──────────────────────────────────────────────
+
+  describe('hashInviteToken', () => {
+    it('produces deterministic output', async () => {
+      const token = generateInviteToken();
+      const hash1 = await hashInviteToken(token);
+      const hash2 = await hashInviteToken(token);
+      expect(hash1).toBe(hash2);
+    });
+
+    it('produces different hashes for different tokens', async () => {
+      const hash1 = await hashInviteToken(generateInviteToken());
+      const hash2 = await hashInviteToken(generateInviteToken());
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('returns a base64url string', async () => {
+      const hash = await hashInviteToken(generateInviteToken());
+      expect(hash).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  // ── Link building ──────────────────────────────────────────────
+
+  describe('buildInviteLink', () => {
+    it('includes token and familyId as query params', () => {
+      const link = buildInviteLink('my-token', 'family-123');
+      expect(link).toContain('t=my-token');
+      expect(link).toContain('f=family-123');
+    });
+
+    it('uses hash-based routing', () => {
+      const link = buildInviteLink('tok', 'fam');
+      expect(link).toContain('#/join');
+    });
+  });
+
+  // ── Expiry check ───────────────────────────────────────────────
+
+  describe('isInviteExpired', () => {
+    it('returns false for future timestamp', () => {
+      const future = new Date(Date.now() + 60_000).toISOString();
+      expect(isInviteExpired(future)).toBe(false);
+    });
+
+    it('returns true for past timestamp', () => {
+      const past = new Date(Date.now() - 60_000).toISOString();
+      expect(isInviteExpired(past)).toBe(true);
+    });
+
+    it('returns true for exactly now', () => {
+      vi.useFakeTimers();
+      const now = new Date().toISOString();
+      expect(isInviteExpired(now)).toBe(true);
+      vi.useRealTimers();
+    });
+  });
+});

--- a/src/services/crypto/familyKeyService.ts
+++ b/src/services/crypto/familyKeyService.ts
@@ -1,0 +1,142 @@
+/**
+ * Family Key Service — per-family AES-256-GCM key with AES-KW wrapping.
+ *
+ * The family key (FK) is a random 256-bit AES-GCM key used to encrypt the
+ * Automerge binary payload. Each family member holds a wrapped copy of the FK,
+ * produced via their password-derived AES-KW key.
+ *
+ * Key design decisions:
+ * - encryptPayload/decryptPayload work with raw Uint8Array (Automerge binary).
+ * - importFamilyKey and unwrapFamilyKey return extractable keys so they can
+ *   be re-wrapped for new members.
+ * - deriveMemberKey outputs AES-KW (for wrapping), unlike encryption.ts
+ *   deriveKey which outputs AES-GCM (for direct encryption).
+ * - Wrong-password errors propagate as native DOMException.
+ */
+
+import { SALT_LENGTH, IV_LENGTH } from './encryption';
+import { bufferToBase64, base64ToBuffer } from '@/utils/encoding';
+
+const ALGORITHM = 'AES-GCM';
+const KEY_LENGTH = 256;
+const WRAPPING_ALGO = 'AES-KW';
+const PBKDF2_ITERATIONS = 100_000;
+
+// ── Key generation & serialization ──────────────────────────────────
+
+/** Generate a new random 256-bit AES-GCM family key. */
+export async function generateFamilyKey(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey({ name: ALGORITHM, length: KEY_LENGTH }, true, [
+    'encrypt',
+    'decrypt',
+  ]);
+}
+
+/** Export a family key to raw bytes. */
+export async function exportFamilyKey(key: CryptoKey): Promise<Uint8Array> {
+  const raw = await crypto.subtle.exportKey('raw', key);
+  return new Uint8Array(raw);
+}
+
+/** Import a family key from raw bytes. Returns an extractable key. */
+export async function importFamilyKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    raw.buffer as ArrayBuffer,
+    { name: ALGORITHM, length: KEY_LENGTH },
+    true,
+    ['encrypt', 'decrypt']
+  );
+}
+
+// ── Member wrapping (password → AES-KW) ────────────────────────────
+
+/** Derive an AES-KW wrapping key from a member's password + salt. */
+export async function deriveMemberKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits', 'deriveKey']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: salt.buffer as ArrayBuffer,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: WRAPPING_ALGO, length: KEY_LENGTH },
+    false,
+    ['wrapKey', 'unwrapKey']
+  );
+}
+
+/** Wrap a family key with an AES-KW wrapping key. Returns base64. */
+export async function wrapFamilyKey(familyKey: CryptoKey, wrappingKey: CryptoKey): Promise<string> {
+  const wrapped = await crypto.subtle.wrapKey('raw', familyKey, wrappingKey, WRAPPING_ALGO);
+  return bufferToBase64(wrapped);
+}
+
+/** Unwrap a family key. Returns an extractable AES-GCM key. */
+export async function unwrapFamilyKey(
+  wrappedBase64: string,
+  unwrappingKey: CryptoKey
+): Promise<CryptoKey> {
+  return crypto.subtle.unwrapKey(
+    'raw',
+    base64ToBuffer(wrappedBase64),
+    unwrappingKey,
+    WRAPPING_ALGO,
+    { name: ALGORITHM, length: KEY_LENGTH },
+    true, // extractable — so the FK can be re-wrapped for new members
+    ['encrypt', 'decrypt']
+  );
+}
+
+// ── Payload encryption (AES-GCM) ───────────────────────────────────
+
+/**
+ * Encrypt an Automerge binary payload with the family key.
+ * Returns `Uint8Array( IV || ciphertext )`.
+ */
+export async function encryptPayload(familyKey: CryptoKey, data: Uint8Array): Promise<Uint8Array> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: ALGORITHM, iv: iv.buffer as ArrayBuffer },
+    familyKey,
+    data.buffer as ArrayBuffer
+  );
+
+  const result = new Uint8Array(IV_LENGTH + ciphertext.byteLength);
+  result.set(iv, 0);
+  result.set(new Uint8Array(ciphertext), IV_LENGTH);
+  return result;
+}
+
+/**
+ * Decrypt an Automerge binary payload with the family key.
+ * Expects `Uint8Array( IV || ciphertext )`.
+ */
+export async function decryptPayload(
+  familyKey: CryptoKey,
+  encrypted: Uint8Array
+): Promise<Uint8Array> {
+  const iv = encrypted.slice(0, IV_LENGTH);
+  const ciphertext = encrypted.slice(IV_LENGTH);
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: ALGORITHM, iv: iv.buffer as ArrayBuffer },
+    familyKey,
+    ciphertext.buffer as ArrayBuffer
+  );
+
+  return new Uint8Array(plaintext);
+}
+
+// Re-export for convenience
+export { SALT_LENGTH, IV_LENGTH };

--- a/src/services/crypto/inviteService.ts
+++ b/src/services/crypto/inviteService.ts
@@ -1,0 +1,121 @@
+/**
+ * Invite Service — token-based family key sharing for new members.
+ *
+ * Flow:
+ * 1. Owner generates an invite token (32 random bytes → base64url).
+ * 2. Token is used to derive an AES-KW key (PBKDF2 with raw token bytes).
+ * 3. The family key is wrapped with that key and stored in the .beanpod file
+ *    keyed by SHA-256(token) so the raw token is never persisted.
+ * 4. New member opens the invite link, enters the token, unwraps the FK,
+ *    then re-wraps it with their own password.
+ * 5. Invite packages expire after 24 hours.
+ */
+
+import { bufferToBase64url, base64urlToBuffer } from '@/utils/encoding';
+import { SALT_LENGTH, wrapFamilyKey, unwrapFamilyKey } from '@/services/crypto/familyKeyService';
+
+const PBKDF2_ITERATIONS = 100_000;
+const KEY_LENGTH = 256;
+const WRAPPING_ALGO = 'AES-KW';
+const INVITE_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// ── Token generation ────────────────────────────────────────────────
+
+/** Generate a cryptographically random invite token (base64url, 43 chars). */
+export function generateInviteToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return bufferToBase64url(bytes);
+}
+
+// ── Key derivation ──────────────────────────────────────────────────
+
+/**
+ * Derive an AES-KW wrapping key from an invite token.
+ * Uses raw token bytes (full 256-bit entropy) as PBKDF2 input.
+ */
+export async function deriveInviteKey(token: string, salt: Uint8Array): Promise<CryptoKey> {
+  const tokenBytes = base64urlToBuffer(token);
+
+  const keyMaterial = await crypto.subtle.importKey('raw', tokenBytes, 'PBKDF2', false, [
+    'deriveBits',
+    'deriveKey',
+  ]);
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: salt.buffer as ArrayBuffer,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: WRAPPING_ALGO, length: KEY_LENGTH },
+    false,
+    ['wrapKey', 'unwrapKey']
+  );
+}
+
+// ── Invite package creation / redemption ────────────────────────────
+
+export interface InvitePackage {
+  salt: string; // base64url
+  wrapped: string; // base64 (AES-KW wrapped FK)
+  expiresAt: string; // ISO 8601
+}
+
+/**
+ * Wrap the family key for an invite link.
+ * Returns the package to store in the .beanpod file.
+ */
+export async function createInvitePackage(
+  familyKey: CryptoKey,
+  token: string
+): Promise<InvitePackage> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+  const wrappingKey = await deriveInviteKey(token, salt);
+  const wrapped = await wrapFamilyKey(familyKey, wrappingKey);
+  const expiresAt = new Date(Date.now() + INVITE_EXPIRY_MS).toISOString();
+
+  return {
+    salt: bufferToBase64url(salt),
+    wrapped,
+    expiresAt,
+  };
+}
+
+/**
+ * Redeem an invite token to recover the family key.
+ * Returns an extractable CryptoKey.
+ */
+export async function redeemInviteToken(
+  wrapped: string,
+  salt: string,
+  token: string
+): Promise<CryptoKey> {
+  const saltBytes = new Uint8Array(base64urlToBuffer(salt));
+  const unwrappingKey = await deriveInviteKey(token, saltBytes);
+  return unwrapFamilyKey(wrapped, unwrappingKey);
+}
+
+// ── Token hashing (storage key) ─────────────────────────────────────
+
+/** Hash an invite token with SHA-256. Returns base64url (storage key). */
+export async function hashInviteToken(token: string): Promise<string> {
+  const data = new TextEncoder().encode(token);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return bufferToBase64url(hash);
+}
+
+// ── Link building ───────────────────────────────────────────────────
+
+/** Build a full invite URL for the app. */
+export function buildInviteLink(token: string, familyId: string): string {
+  return `${globalThis.location?.origin ?? 'https://beanies.family'}/#/join?t=${encodeURIComponent(token)}&f=${encodeURIComponent(familyId)}`;
+}
+
+// ── Expiry check ────────────────────────────────────────────────────
+
+/** Check whether an invite package has expired. */
+export function isInviteExpired(expiresAt: string): boolean {
+  return new Date(expiresAt).getTime() <= Date.now();
+}

--- a/src/types/syncFileV4.ts
+++ b/src/types/syncFileV4.ts
@@ -1,0 +1,60 @@
+/**
+ * Beanpod file format v4.0 — family-key encryption with per-member wrapping.
+ *
+ * Replaces the v3.0 single-password model with:
+ * - A random 256-bit AES-GCM family key (FK)
+ * - Per-member wrapped copies (password-derived AES-KW)
+ * - Per-passkey wrapped copies (PRF/HKDF-derived AES-KW)
+ * - Invite-link wrapped copies (token-derived AES-KW, 24h expiry)
+ * - AES-GCM encrypted Automerge binary payload
+ */
+
+import type { UUID, ISODateString } from './models';
+
+/** A family key wrapped with a member's password-derived AES-KW key. */
+export interface WrappedMemberKey {
+  /** PBKDF2 salt (base64, 16 bytes) */
+  salt: string;
+  /** AES-KW wrapped family key (base64) */
+  wrapped: string;
+}
+
+/** A family key wrapped with a passkey's PRF-derived AES-KW key. */
+export interface WrappedPasskeyKey {
+  /** AES-KW wrapped family key (base64) */
+  wrapped: string;
+  /** HKDF salt used to derive the wrapping key (base64, 32 bytes) */
+  hkdfSalt: string;
+}
+
+/** A family key wrapped for an invite link (token-derived AES-KW, time-limited). */
+export interface InviteKeyPackage {
+  /** PBKDF2 salt (base64, 16 bytes) */
+  salt: string;
+  /** AES-KW wrapped family key (base64) */
+  wrapped: string;
+  /** ISO 8601 expiration timestamp (24h from creation) */
+  expiresAt: ISODateString;
+}
+
+/** Beanpod file format v4.0 */
+export interface BeanpodFileV4 {
+  version: '4.0';
+  familyId: UUID;
+  familyName: string;
+
+  /** Key rotation identifier — changes when the family key is rotated. */
+  keyId: string;
+
+  /** Per-member wrapped family keys. Key = memberId. */
+  wrappedKeys: Record<string, WrappedMemberKey>;
+
+  /** Per-passkey wrapped family keys. Key = credentialId (base64url). */
+  passkeyWrappedKeys: Record<string, WrappedPasskeyKey>;
+
+  /** Active invite packages. Key = SHA-256 hash of invite token (base64url). */
+  inviteKeys: Record<string, InviteKeyPackage>;
+
+  /** base64( IV || AES-GCM(FK, automerge_binary) ) */
+  encryptedPayload: string;
+}

--- a/src/utils/__tests__/encoding.test.ts
+++ b/src/utils/__tests__/encoding.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { bufferToBase64, base64ToBuffer, bufferToBase64url, base64urlToBuffer } from '../encoding';
+
+describe('encoding', () => {
+  describe('bufferToBase64 / base64ToBuffer', () => {
+    it('round-trips arbitrary binary data', () => {
+      const original = new Uint8Array([0, 1, 127, 128, 255, 42, 99]);
+      const b64 = bufferToBase64(original);
+      const restored = new Uint8Array(base64ToBuffer(b64));
+      expect(restored).toEqual(original);
+    });
+
+    it('handles empty buffer', () => {
+      const empty = new Uint8Array(0);
+      const b64 = bufferToBase64(empty);
+      const restored = new Uint8Array(base64ToBuffer(b64));
+      expect(restored).toEqual(empty);
+    });
+
+    it('accepts ArrayBuffer input', () => {
+      const bytes = new Uint8Array([10, 20, 30]);
+      const b64 = bufferToBase64(bytes.buffer as ArrayBuffer);
+      const restored = new Uint8Array(base64ToBuffer(b64));
+      expect(restored).toEqual(bytes);
+    });
+  });
+
+  describe('bufferToBase64url / base64urlToBuffer', () => {
+    it('round-trips arbitrary binary data', () => {
+      const original = new Uint8Array([0, 1, 127, 128, 255, 42, 99]);
+      const b64url = bufferToBase64url(original);
+      const restored = new Uint8Array(base64urlToBuffer(b64url));
+      expect(restored).toEqual(original);
+    });
+
+    it('produces URL-safe output (no +, /, = chars)', () => {
+      // Use bytes that would produce +, /, and = in standard base64
+      const data = new Uint8Array(256);
+      for (let i = 0; i < 256; i++) data[i] = i;
+      const b64url = bufferToBase64url(data);
+      expect(b64url).not.toMatch(/[+/=]/);
+    });
+
+    it('handles empty buffer', () => {
+      const empty = new Uint8Array(0);
+      const b64url = bufferToBase64url(empty);
+      const restored = new Uint8Array(base64urlToBuffer(b64url));
+      expect(restored).toEqual(empty);
+    });
+  });
+});

--- a/src/utils/__tests__/qrCode.test.ts
+++ b/src/utils/__tests__/qrCode.test.ts
@@ -1,0 +1,10 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { generateInviteQR } from '../qrCode';
+
+describe('generateInviteQR', () => {
+  it('returns a PNG data URL', async () => {
+    const url = await generateInviteQR('https://beanies.family/#/join?t=abc&f=123');
+    expect(url).toMatch(/^data:image\/png;base64,/);
+  });
+});

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared binary ↔ string encoding utilities.
+ *
+ * These are used by the family-key and invite crypto services.
+ * Existing files (encryption.ts, passkeyCrypto.ts) keep their private copies
+ * for now — consolidation is a separate cleanup task.
+ */
+
+/** Convert an ArrayBuffer / Uint8Array to a standard base64 string. */
+export function bufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+/** Convert a standard base64 string back to an ArrayBuffer. */
+export function base64ToBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer as ArrayBuffer;
+}
+
+/** Convert an ArrayBuffer / Uint8Array to a URL-safe base64 string (no padding). */
+export function bufferToBase64url(buffer: ArrayBuffer | Uint8Array): string {
+  return bufferToBase64(buffer).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Convert a URL-safe base64 string back to an ArrayBuffer. */
+export function base64urlToBuffer(base64url: string): ArrayBuffer {
+  let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  // Restore padding
+  while (base64.length % 4 !== 0) {
+    base64 += '=';
+  }
+  return base64ToBuffer(base64);
+}

--- a/src/utils/qrCode.ts
+++ b/src/utils/qrCode.ts
@@ -1,0 +1,18 @@
+/**
+ * QR code generation for invite links.
+ * Uses brand colors: Deep Slate dots on white background.
+ */
+
+import QRCode from 'qrcode';
+
+/** Generate a PNG data-URL QR code for an invite link. */
+export async function generateInviteQR(inviteUrl: string): Promise<string> {
+  return QRCode.toDataURL(inviteUrl, {
+    width: 256,
+    margin: 2,
+    color: {
+      dark: '#2C3E50', // Deep Slate
+      light: '#FFFFFF',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Add per-family AES-256-GCM family key with AES-KW wrapping for the Automerge migration (#111, #119 epic)
- New `familyKeyService` — key generation, export/import, password-derived member wrapping, and AES-GCM payload encryption/decryption for Automerge binary
- New `inviteService` — token generation, token-derived key wrapping, SHA-256 token hashing, invite link building, and 24h expiry
- New `syncFileV4.ts` types — `BeanpodFileV4` file format with per-member, per-passkey, and invite wrapped keys
- New shared `encoding.ts` utility — `bufferToBase64`, `base64ToBuffer`, `bufferToBase64url`, `base64urlToBuffer`
- New `qrCode.ts` utility — QR code generation with brand colors (Deep Slate on white)
- 37 new unit tests across 4 test files (all crypto tests use `// @vitest-environment node`)
- Purely additive — no existing code modified

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run test:run` — 610/610 pass (43 test files)
- [x] `npm run build` — production build succeeds
- [x] `npm run lint` — 0 new errors

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)