### PR TITLE
fix(e2e): harden WebKit E2E stability (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ent
 
 - E2E tests run with `prefers-reduced-motion: reduce` and decorative infinite CSS animations are disabled under that preference — improves test reliability on WebKit and respects the accessibility preference for real users (#153)
 - E2E CI workflows consolidated — `main-ci.yml` no longer duplicates the Playwright pipeline; `e2e.yml` handles all E2E runs with an event-aware matrix (main push: Chromium; `run-e2e` PR label: Chromium + WebKit; weekly: all three)
+- WebKit E2E stability — reduced-motion rule now also zeroes out CSS `transition-duration` (not just `animation-*`), page-object `goto()` calls use `waitUntil: 'domcontentloaded'` so a slow/missing `load` event no longer hangs navigation, and the webkit Playwright project has a 40s per-test timeout to absorb its ~2–3× slower Linux CI runtime (#155)
 
 ---
 

--- a/e2e/page-objects/AccountsPage.ts
+++ b/e2e/page-objects/AccountsPage.ts
@@ -6,7 +6,7 @@ export class AccountsPage {
   constructor(private page: Page) {}
 
   async goto() {
-    await this.page.goto('/accounts');
+    await this.page.goto('/accounts', { waitUntil: 'domcontentloaded' });
   }
 
   getInstitutionCombobox() {

--- a/e2e/page-objects/AssetsPage.ts
+++ b/e2e/page-objects/AssetsPage.ts
@@ -6,7 +6,7 @@ export class AssetsPage {
   constructor(private page: Page) {}
 
   async goto() {
-    await this.page.goto('/assets');
+    await this.page.goto('/assets', { waitUntil: 'domcontentloaded' });
   }
 
   getLenderCombobox() {

--- a/e2e/page-objects/DashboardPage.ts
+++ b/e2e/page-objects/DashboardPage.ts
@@ -4,7 +4,7 @@ export class DashboardPage {
   constructor(private page: Page) {}
 
   async goto() {
-    await this.page.goto('/dashboard');
+    await this.page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
   }
 
   /** Click the privacy mode unlock button to reveal masked financial figures */

--- a/e2e/page-objects/TransactionsPage.ts
+++ b/e2e/page-objects/TransactionsPage.ts
@@ -19,7 +19,7 @@ export class TransactionsPage {
   constructor(private page: Page) {}
 
   async goto() {
-    await this.page.goto('/transactions');
+    await this.page.goto('/transactions', { waitUntil: 'domcontentloaded' });
   }
 
   /**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,14 @@ export default defineConfig({
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
     // Firefox and WebKit available for local testing: npx playwright test --project=firefox
     { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    {
+      name: 'webkit',
+      // WebKit on Linux CI is ~2–3× slower than Chromium for the same flows.
+      // Bump per-test timeout so genuine webkit regressions surface distinctly
+      // from general slowness (see issue #155).
+      timeout: 40000,
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
   webServer: {
     command: 'npm run dev',

--- a/src/style.css
+++ b/src/style.css
@@ -385,16 +385,20 @@
     transform: none;
   }
 
-  /* Disable all infinite CSS animations globally — covers the decorative
-     floats on HomePage (decoFloat1/2, mascotFloat, heroFloat) and anywhere
-     else we use infinite keyframes. This also eliminates a class of
-     Playwright-webkit "stable" timeouts caused by repaint churn from
-     animated siblings. */
+  /* Universal kill-switch: removes every transition and animation so
+     Playwright's "stable" check (two-frame bounding-box equality) passes
+     immediately. Essential on WebKit CI, which otherwise stalls on infinite
+     decorative animations (floating mascots, hero device mocks) and on
+     modal/drawer enter transitions (see issue #155). */
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
+    animation-delay: 0s !important;
+    animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-delay: 0s !important;
+    transition-duration: 0.001ms !important;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #155 — the 10 webkit-only E2E timeouts that remained after PR #154.

Three narrow fixes addressing three distinct failure patterns observed in the trace artifacts from run 24340602771:

- **"Waiting for element to be stable" stalls** — extended the reduced-motion rule in `src/style.css` to zero out `transition-duration` globally (not just `animation-*`). Vue modal/drawer enter transitions (`transition-all duration-200`) were keeping dialog buttons "unstable" for webkit's scheduler, stacking with infinite decorative animations on HomePage that PR #154's partial rule missed.
- **`page.goto('/transactions')` hang** — page-object `goto()` methods now pass `waitUntil: 'domcontentloaded'`. WebKit's `load` event sometimes never fires in CI (likely PWA service worker / font / Plausible request), blocking navigation for the full 20s.
- **General webkit slowness** — webkit Playwright project now has a 40s per-test timeout. WebKit on Linux CI is ~2–3× slower than Chromium on the same runner, so real webkit-only regressions can surface distinctly from "just slow".

## Test plan

- [x] `npm run type-check` — green
- [x] `npx playwright test --project=chromium` (sample: Activity CRUD + Create account / dashboard net worth) — green
- [ ] **CI must confirm webkit passes** — apply `run-e2e` before merge. Target: 0 webkit failures (was 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)