### PR TITLE
feat(auth): native biometric (passkey) login via WebView WebAuthn (ADR-029)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,6 +178,12 @@ jobs:
         with:
           name: dist
           path: dist/
+          # Include dotfiles so dist/.well-known/ (assetlinks.json for native
+          # WebAuthn association + apple-app-site-association) survives the
+          # artifact round-trip and reaches S3. upload-artifact strips hidden
+          # files by default; aws s3 sync itself preserves them. Same fix as
+          # deploy-web.yml for the apex. See ADR-029.
+          include-hidden-files: true
           retention-days: 1
 
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ent
 
 ---
 
+## 2026-05-23
+
+### Added
+
+- **Biometric unlock now works in the native app, not just the browser.** Face ID, fingerprint, and device-PIN sign-in (passkeys) now work inside the native Android app — using the same passkeys you set up on the website, with no re-enrollment. Under the hood the app's WebView now supports WebAuthn and is associated with `app.beanies.family` so your existing passkeys are recognized. On older devices that can't do passkeys, sign-in cleanly falls back to your password (and the app no longer shows a confusing "your browser doesn't support…" message). Biometrics never leave your device, and your family password always remains the master key. iOS support is configured and ships when the iOS app is built. (See ADR-029.)
+
 ## 2026-05-22
 
 ### Fixed

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,10 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    // WebAuthn (passkey / biometric login) inside the WebView, via
+    // WebSettingsCompat.setWebAuthenticationSupport. WEB_AUTHENTICATION feature
+    // requires androidx.webkit >= 1.12.0. See ADR-029.
+    implementation "androidx.webkit:webkit:1.12.1"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/app/src/main/java/family/beanies/app/MainActivity.java
+++ b/android/app/src/main/java/family/beanies/app/MainActivity.java
@@ -1,5 +1,50 @@
 package family.beanies.app;
 
+import android.os.Bundle;
+import android.util.Log;
+import android.webkit.WebSettings;
+
+import androidx.webkit.WebSettingsCompat;
+import androidx.webkit.WebViewFeature;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    private static final String TAG = "beanies";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        enableWebAuthnIfSupported();
+    }
+
+    /**
+     * Enable WebAuthn (passkeys / biometric login) inside the Capacitor WebView,
+     * routed through the Android Credential Manager. App-scoped — passkeys for the
+     * app's associated domain only (see the WebAuthn Digital Asset Links at
+     * https://app.beanies.family/.well-known/assetlinks.json), NOT browser-scoped.
+     *
+     * Feature-detected: older System WebViews lack WEB_AUTHENTICATION, in which case
+     * window.PublicKeyCredential stays undefined in JS and biometric unlock falls
+     * back to password (Tier 3). Never crash the Activity over this. See ADR-029 and
+     * docs/plans/2026-05-23-native-pwa-biometric-login.md.
+     */
+    private void enableWebAuthnIfSupported() {
+        try {
+            if (!WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+                Log.w(TAG, "WebView WEB_AUTHENTICATION feature unsupported on this System WebView; "
+                        + "biometric unlock falls back to password (ADR-029).");
+                return;
+            }
+            WebSettings settings = getBridge().getWebView().getSettings();
+            WebSettingsCompat.setWebAuthenticationSupport(
+                    settings,
+                    WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP
+            );
+        } catch (Exception e) {
+            // Developer breadcrumb — JS can't observe native enablement state.
+            Log.w(TAG, "Failed to enable WebView WebAuthn; biometric unlock falls back to password "
+                    + "(ADR-029).", e);
+        }
+    }
+}

--- a/docs/plans/2026-05-23-native-pwa-biometric-login.md
+++ b/docs/plans/2026-05-23-native-pwa-biometric-login.md
@@ -1,0 +1,144 @@
+# Plan: Biometric (passkey) login across native apps + PWA + browser — one implementation, every platform
+
+> Date: 2026-05-23 · Related issues: None — direct implementation
+> On approval, this is saved to `docs/plans/2026-05-23-native-pwa-biometric-login.md` (project convention) and `.draft-native-biometric.md` is removed.
+> Built via the 4-pass `/beanies-plan` discipline (records at the end).
+
+## Context
+
+Native Android biometric login is broken and Settings shows "your browser does not support biometric login (WebAuthn)". beanies already has a complete, well-built WebAuthn/passkey stack on web+PWA — PRF extension → HKDF → AES-KW unwrap of the family key, a three-tier unlock (PRF → cached family-key on a trusted device → password), cross-device sync (iCloud/Google), the Signal API, progressive registration fallbacks. **The crypto/envelope design is sound and is reused unchanged; this is about making that same machinery run inside the Capacitor WebView and hardening capability messaging so the experience is consistent everywhere.**
+
+Two confirmed native root causes (same `https://localhost`-origin family as the just-fixed OAuth issue, ADR-029): (1) the Android WebView doesn't expose `window.PublicKeyCredential` unless the app opts in via `androidx.webkit`; (2) `rpId = window.location.hostname` resolves to `localhost`, which can't match the PWA passkey's RP ID (`app.beanies.family`). WebAuthn can't be CORS-allowlisted away — it needs platform association (Digital Asset Links on Android, AASA on iOS).
+
+**Honest framing of "all devices, newer & older":** WebAuthn/passkeys are a platform credential API and **cannot be polyfilled**. "Consistent across all devices" = a consistent _experience_: passkey-capable devices get one-tap biometrics; every other device falls back **cleanly** to password — never a broken/confusing state. This plan defines those tiers; it does not put passkeys on platforms that lack them.
+
+**Chosen approach: WebView-WebAuthn** — enable WebAuthn in the native WebView and reuse the existing JS passkey stack via a small `getRpId()` seam + native association. **Rejected alternative:** a native Capacitor passkey plugin (Credential Manager/ASAuthorization bridge) — it forks the `navigator.credentials` surface, likely loses the PRF extension the family-key design depends on, and adds a security-sensitive dependency. Revisit only if WebView-WebAuthn proves unworkable on target devices.
+
+## User Story
+
+As a member, I want to unlock my pod with device biometrics (Face ID / Touch ID / fingerprint / PIN) in the native app, the installed PWA, and the browser alike — and on devices that can't do passkeys, be cleanly returned to my password rather than hit a dead end.
+
+## Requirements
+
+1. Native Android biometric login works end-to-end (register in-app → unlock on next sign-in), reusing the existing PRF/family-key machinery.
+2. iOS native readiness: all iOS config (Associated Domains + AASA) in place; on-device validation deferred to the first iOS build (none exists yet).
+3. PWA + browser biometric unchanged — **zero regression**; existing passkeys keep working with no re-enrollment; dev (`localhost:5173`) + self-hosters keep working.
+4. A cross-platform RP-ID strategy that works on web origin `app.beanies.family` AND the native `localhost` WebView origin **without invalidating existing credentials**.
+5. Accurate capability tiering + graceful password fallback on every surface — never "your browser doesn't support…" inside a native app.
+6. No silent failures: native-config / capability / assertion / unwrap failures each surface a user message + a developer breadcrumb.
+7. PRF-uncertainty resilience on native: Android Credential Manager PRF support isn't guaranteed; the cached-key + password fallbacks must cover the no-PRF case (the existing cross-device path already does).
+8. Digital Asset Links / AASA hosted on the correct origins.
+
+## Important Notes & Caveats
+
+- **Reuse, don't rewrite.** `passkeyService.ts`, `passkeyCrypto.ts`, the `passkeyWrappedKeys` envelope path, the three-tier unlock, cross-device handling, the Signal API all stay. The substantive JS change is a single `getRpId()` seam + a copy reword. Everything else is native project config.
+- **RP ID must NOT change for existing web users.** Current passkeys registered with `rpId = window.location.hostname = 'app.beanies.family'`. `getRpId()` MUST keep returning `app.beanies.family` on the prod PWA (a no-op for web). Changing it to the apex would silently orphan every existing passkey. **(Pass 4 verified: RP-ID unchanged ⇒ no orphaned credentials.)**
+- **RP ID is origin-derived on web, association-authorized on native.** Web → must be the origin's registrable domain (`app.beanies.family` prod, `localhost` dev). Native → WebView origin is `localhost` but the Digital-Asset-Links/AASA association authorizes the app to assert RP ID `app.beanies.family`. That association _is_ the mechanism.
+- **WebAuthn assetlinks lives on `app.beanies.family` (the Vue app's bucket), not the apex.** The existing App-Link `assetlinks.json` is in `web/public/.well-known/` → served from `beanies.family` (Astro, `handle_all_urls`). WebAuthn needs `delegate_permission/common.get_login_creds` on the **RP-ID domain** `app.beanies.family` → a NEW `public/.well-known/assetlinks.json` in the **Vue app** (its `public/` currently holds only `security.txt`). Same package + fingerprint, different relation/origin/deploy target.
+- **Two assetlinks files now exist on two origins — keep fingerprints in sync.** At every signing-key event (debug keystore rotation, release/upload key, Play App Signing, a future second app) BOTH files must be updated together or native auth breaks silently on the un-updated origin. Document in an adjacent README. (The apex file currently lists only the debug fingerprint — confirm whether release must be added there too; pre-existing, don't expand.)
+- **Android WebView WebAuthn needs a recent System WebView** (`WebViewFeature.WEB_AUTHENTICATION`). Feature-detect in native code; older WebViews → graceful Tier-3 fallback, never a crash.
+- **`server.hostname` is intentionally NOT changed.** Keep the WebView at `https://localhost` (preserves the just-shipped OAuth `https://localhost` CORS fix) and rely on association. Do not repoint the WebView origin.
+- **`attestation: 'none'` stays** (self-relying-party, no server-side attestation). Enable WebAuthn app-scoped (`WEB_AUTHENTICATION_SUPPORT_FOR_APP`), never `…_FOR_BROWSER`.
+- **iOS can't be fully validated this cycle** (no iOS build). Config is shipped + documented; iOS acceptance gates on replacing the `<APPLE_TEAM_ID>` placeholder.
+
+## Assumptions (verify before/at implementation)
+
+1. Prod PWA serves at `app.beanies.family`; existing passkeys' RP ID is `app.beanies.family`. Verify no users still hold passkeys under the pre-cutover apex (pre-existing concern if so; don't expand scope).
+2. The app signing-cert SHA-256 fingerprints are known (debug `19:E4:…` for testing; release for prod) and match what the WebAuthn assetlinks lists.
+3. **The app deploy currently does NOT ship hidden files** — `deploy.yml`'s `upload-artifact@v7` (`:176-181`) lacks `include-hidden-files: true`, so `dist/.well-known/` is silently stripped before `aws s3 sync` (the apex `deploy-web.yml:49` was fixed; the app deploy wasn't). This plan adds the fix; verify live with `curl -sI https://app.beanies.family/.well-known/assetlinks.json` → 200, `application/json`.
+4. greg's Pixel 10 Pro (Android 16) supports `WebViewFeature.WEB_AUTHENTICATION` — verify on-device.
+5. PRF via Android Credential Manager is **uncertain** — plan does not depend on it; verify empirically whether PRF round-trips (if yes, native gets full unwrap; if no, biometric verifies the member and cached-key/password completes — both acceptable).
+
+## Approach
+
+### Part 1 — JS seam: a single `getRpId()` (the only substantive JS logic change)
+
+- Add `getRpId()` **co-located in `passkeyService.ts`** (one consumer, one file — no `webauthnConfig.ts` module).
+  - **Web** (`!isNative()`): return `window.location.hostname` verbatim (zero change for web/dev/self-host).
+  - **Native** (`isNative()` from `@/services/sync/capabilities`): return a module-local `const WEBAUTHN_RP_ID = 'app.beanies.family'` declared next to `RP_NAME` (`:25`). **Do NOT** source it from `features.ts` `CLOUD_HOSTS` (that gates `getDeploymentMode()` — unrelated deployment infra; coupling auth's RP-ID to it is the wrong dependency). **Do NOT** add `VITE_WEBAUTHN_RP_ID` (RP-ID is fixed product infra tied to the assetlinks/AASA we host, not a per-deploy knob). `features.ts` is **not touched**.
+- Replace the three `window.location.hostname` WebAuthn sites — registration `:84`, assertion `:218`, Signal API `:444` (grep-confirmed the ONLY rpId sites) — with `getRpId()`. That is the entire RP-ID change.
+
+### Part 2 — Capability detection & tiering (honest, native-aware)
+
+- After Part 3 enables WebAuthn, `window.PublicKeyCredential` becomes defined on capable native devices, so the **existing** `isWebAuthnSupported()` / `isPlatformAuthenticatorAvailable()` checks Just Work — **no JS capability rewrite, no `isNative()` branch in `PasskeySettings.vue`**. The change is purely copy:
+  - **Reword the existing `passkey.unsupported` key** (`uiStrings.ts:3128`, currently `'Your browser does not support biometric login (WebAuthn).'`, rendered at `PasskeySettings.vue:110` under `v-if="!supported"`) to be **surface-neutral** — e.g. en: `"Biometric unlock isn't available on this device. Use your password to sign in."` Provide `{en, beanie}` only — `zh`/other locales are auto-generated by the translation pipeline (matches the existing `passkey.*` entries); do not hand-author them. Drop the word "browser" and any hardware-capability absolute.
+  - Leave `passkey.noAuthenticator` (`:3114`, "No biometric authenticator detected on this device", rendered at `:149`) — already native-safe.
+- **Capability ladder (documentation of existing checks, NOT a code construct — no `Tier` enum/resolver):**
+  - Tier 1 — passkey + PRF: full one-tap unwrap (modern web; native iff Credential Manager supplies PRF).
+  - Tier 2 — passkey, no PRF: biometric verifies the member; family key from cached-key (trusted device) or password (the existing cross-device path).
+  - Tier 3 — no platform authenticator / old WebView / iOS<16 / old browser: password only + the surface-neutral message.
+  - _Consequence to accept:_ a Tier-3 native device (capable hardware, WebView lacking `WEB_AUTHENTICATION`) shows the same reworded `passkey.unsupported` copy as an old browser — intentional, hence the surface-neutral wording. New capability behavior belongs in the existing checks; reconsider an abstraction only if a genuine 4th path emerges.
+
+### Part 3 — Android native enablement
+
+- Add `androidx.webkit` (≥ 1.12.1) to `android/app/build.gradle`.
+- In `MainActivity.java` (currently bare `BridgeActivity`): feature-detect `WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)` and, if supported, `WebSettingsCompat.setWebAuthenticationSupport(webSettings, WEB_AUTHENTICATION_SUPPORT_FOR_APP)`. If unsupported, no-op (JS sees no `PublicKeyCredential` → Tier-3 fallback). Wrap in try/catch with `Log.w(...)` on failure (developer breadcrumb — JS can't observe native enablement) — never crash the Activity.
+- Add **WebAuthn Digital Asset Links** as a NEW `public/.well-known/assetlinks.json` in the Vue app: `delegate_permission/common.get_login_creds`, `package_name: family.beanies.app`, matching SHA-256 fingerprint(s) (debug `19:E4:…` for testing; release for prod). The apex App-Link file stays as-is.
+- **Fix the deploy artifact strip (critical):** add `include-hidden-files: true` to the `actions/upload-artifact@v7` step in `.github/workflows/deploy.yml` (`:176-181`). Without it the new `assetlinks.json` (and the AASA) are silently dropped from the CI artifact → 404 → association silently fails → native biometrics silently never appear.
+
+### Part 4 — iOS native readiness (config now, validate at iOS build)
+
+- Add the **Associated Domains** entitlement `webcredentials:app.beanies.family` to the iOS project (once `npx cap add ios` scaffolding exists).
+- Host an **AASA** at `https://app.beanies.family/.well-known/apple-app-site-association` (HTTP 200, no `.json` extension, `application/json`), `webcredentials.apps: ['<APPLE_TEAM_ID>.family.beanies.app']` — commit with an explicit `<APPLE_TEAM_ID>` placeholder + comment. A placeholder file on the live origin is harmless (iOS won't match it) and safe to deploy now, but iOS WebAuthn silently never associates until it's replaced — so the iOS acceptance criterion gates on substituting the real team ID. Add to the Vue app `public/.well-known/`.
+
+### Part 5 — Error handling & messaging (no silent failures)
+
+- Native WebView enablement failure → `Log.w(...)` in `MainActivity` + graceful Tier-3 fallback.
+- **Error classification is already complete for native — do not extend it.** `formatCredentialManagerError()` (`:609`) already maps `NotReadableError`/`NotSupportedError`/`SecurityError`, and the `NotReadableError` PRF-strip retry (`:237`) was added for the Android Credential Manager case. `NotAllowedError` is deliberately handled as `cancelled` (`:118`/`:247`) and must NOT be folded in. **The one real gap:** zero developer breadcrumbs in `passkeyService.ts`. Add a single `reportError()` in `formatCredentialManagerError`'s fallthrough/unknown-error branch (`:621`): `reportError({ surface: 'passkey-assertion', message, error: err, severity: 'warning', context: { domException: (err as DOMException).name, platform: getPlatform() } })` (import `getPlatform` from `@/services/sync/capabilities`). `warning` because the password fallback still completes; `errorReporter.ts`'s reentry-guard + 60s dedup cover floods. Do NOT report the known/`cancelled` cases (de-noised, triage 2026-05-02).
+- A failed family-key unwrap on native (no PRF, no cache) lands on the password prompt — the existing cross-device partial-success path (`memberId`-only result → `crossDeviceContext` + `passkey.crossDeviceNoCache` in `BiometricLoginView.vue`) is platform-agnostic and already does this; verify it triggers on native.
+- Settings: reword the misleading "unsupported" copy (Part 2).
+
+## Files Affected
+
+- `src/services/auth/passkeyService.ts` — add `const WEBAUTHN_RP_ID` next to `RP_NAME` (`:25`); add `getRpId()`; replace 3× `window.location.hostname` (`:84/:218/:444`); add one `reportError()` in the `formatCredentialManagerError` fallthrough (`:621`).
+- `src/services/translation/uiStrings.ts` — reword `passkey.unsupported` (`{en, beanie}` only).
+- `android/app/build.gradle` — `androidx.webkit` dependency.
+- `android/app/src/main/java/family/beanies/app/MainActivity.java` — feature-detected `setWebAuthenticationSupport` + `Log.w` on failure.
+- `public/.well-known/assetlinks.json` — **NEW** (Vue app / app.beanies.family), WebAuthn `get_login_creds`.
+- `public/.well-known/apple-app-site-association` — **NEW** (Vue app), iOS `webcredentials` with `<APPLE_TEAM_ID>` placeholder.
+- `public/.well-known/README.md` — **NEW** documenting the two-origin assetlinks + fingerprint-sync discipline (mirror/reference `web/public/.well-known/README.md`).
+- `.github/workflows/deploy.yml` — `include-hidden-files: true` on `upload-artifact@v7` (`:176-181`). _(No other workflow files; no env-var plumbing.)_
+- iOS project entitlements (Associated Domains) — once iOS scaffolding exists.
+- `src/config/features.ts` — **NOT touched** (RP-ID self-owned in `passkeyService.ts`).
+- Tests: `passkeyService` (`getRpId()` native vs web), existing passkey suite stays green, `PasskeySettings` reworded copy renders.
+
+## Help Center Coverage
+
+- **Action**: update existing (or new if none) · **Category**: `security` · **Type**: how-to/explainer
+- **Slug**: existing biometric/passkey article in `web/src/…/help/security/…`, or new `biometric-login`
+- **Title**: "Unlock with biometrics (Face ID, fingerprint, device PIN)"
+- **Scope**: how to enable biometric unlock; works in the app and the browser; it's a convenience layer over your family password (the password is always the fallback — losing the device ≠ losing the pod); honest device requirement (recent Android/iOS; older devices use the password); privacy story (biometrics never leave the device; beanies only ever sees the wrapped key); a passkey set up on one device syncs to the same platform's other devices (iCloud/Google) but not across ecosystems.
+
+## Acceptance Criteria
+
+- [ ] Native Android: register a passkey in-app → sign out → biometric unlock → pod opens (PRF) or falls back cleanly to password (no-PRF); no "browser unsupported" message.
+- [ ] `getRpId()` → `app.beanies.family` on native, origin host on web; existing web passkeys still authenticate (no re-enrollment).
+- [ ] Settings → Account on native shows accurate, surface-neutral capability copy.
+- [ ] Older-WebView / feature-disabled Android: no crash, Tier-3 password fallback, honest message.
+- [ ] PWA + desktop browser biometric unchanged (incl. dev `localhost:5173`).
+- [ ] `https://app.beanies.family/.well-known/assetlinks.json` (WebAuthn relation) live (HTTP 200, `application/json`).
+- [ ] iOS config (Associated Domains + AASA) committed with `<APPLE_TEAM_ID>` placeholder; iOS on-device acceptance gated on replacing it (deferred to iOS build).
+- [ ] No silent failures: native enablement, capability, assertion, unwrap each surface user message + dev breadcrumb.
+- [ ] Help Center article added/updated and matches shipped behavior.
+- [ ] `npm run validate` green; new + existing passkey tests pass.
+
+## Verification / Testing
+
+1. **Unit** — `getRpId()`: native (`isNative()` true) → `'app.beanies.family'`; web → `window.location.hostname` (mock `isNative`). Existing passkey suite stays green. `PasskeySettings` reworded copy renders.
+2. **Manual — Android APK (greg)**: Settings → enable biometric → register (Credential Manager prompt appears, proving assetlinks resolved) → sign out → biometric unlock. Capture both PRF-present and PRF-absent outcomes. If feasible, test an older-WebView path (Tier-3).
+3. **Manual — PWA/desktop regression**: existing passkey on `app.beanies.family` still unlocks; dev `localhost` still works.
+4. **Manual — iOS**: deferred to iOS build; now just `curl -sI https://app.beanies.family/.well-known/apple-app-site-association` reachability.
+5. **Live asset check**: `curl -sI https://app.beanies.family/.well-known/assetlinks.json` → 200 + `application/json` after deploy.
+6. **`#beanies-errors` watch**: native passkey breadcrumbs quiet/expected; the new `passkey-assertion` warning only fires on genuinely unrecognized failures.
+
+## Review Passes
+
+- **Pass 1 (Initial draft)**: WebView-WebAuthn approach (reuse JS passkey/PRF stack via `getRpId()` + native association), honest capability tiers, Android enablement (androidx.webkit + assetlinks on app.beanies.family), iOS readiness (Associated Domains + AASA), no-existing-passkey-breakage RP-ID constraint, rejected native-plugin alternative.
+- **Pass 2 (DRY + error handling)**: collapsed seam to `getRpId()` in `passkeyService.ts`; reworded existing `passkey.unsupported` instead of new key; found `formatCredentialManagerError` + `NotReadableError` retry already cover native (only gap = no breadcrumb → added one); caught the critical silent failure that `deploy.yml`'s `upload-artifact` lacks `include-hidden-files` (would strip the new assetlinks).
+- **Pass 3 (Sustainability)**: decoupled native RP-ID host from `features.ts` into a self-owned `WEBAUTHN_RP_ID` constant; removed stale rejected artifacts (`webauthnConfig.ts`, `VITE_WEBAUTHN_RP_ID`); corrected the impossible `zh:` instruction ({en, beanie?} + auto-gen); pinned "tiers are docs, not a class"; added two-origin fingerprint-sync discipline + iOS team-ID placeholder guard.
+- **Pass 4 (Fresh-eyes sweep)**: verdict ready-with-minor-edits; verified security-correct (RP-ID unchanged ⇒ no orphaned passkeys, app-scoped WebView WebAuthn, two distinct-origin assetlinks); brought Files-Affected/Approach/Testing text into line with Pass-3 decisions; pinned breadcrumb severity/context, AASA placeholder lifecycle, fingerprint-sync README.
+
+## Prompt Log
+
+- **Initial (/beanies-plan)**: "make a plan to implement biometric login on the native app while ensuring biometric login remains clean and robust on the PWA and browser, and ensure biometric login should work seamlessly across all platforms, including android, iOS, and other relevant platforms. also please ensure that biometric login should work across both newer and older devices ensuring the necessary code paths, polyfills, etc are in place to ensure biometric login works consistently across all android and iOS devices, both newer and older."
+- **Preceding context**: on the native Android APK (post-OAuth-fix), login works but biometric wasn't offered despite a PWA-saved passkey, and Settings shows "your browser does not support biometric login (WebAuthn)". Diagnosis established: native WebView doesn't expose `PublicKeyCredential`, and `rpId = window.location.hostname = 'localhost'` can't match the PWA passkey's RP ID (`app.beanies.family`).

--- a/docs/prompts/2026-05/2026-05-23-native-biometric-login.md
+++ b/docs/prompts/2026-05/2026-05-23-native-biometric-login.md
@@ -1,0 +1,50 @@
+---
+date: 2026-05-23
+category: feature
+issue: none
+plan: docs/plans/2026-05-23-native-pwa-biometric-login.md
+tags: [auth, security, passkey, webauthn, biometric, capacitor, native, pwa, adr-029]
+---
+
+# Native biometric (passkey) login
+
+## Prompts
+
+**[bug report — on native APK]**
+
+> I've installed the new app and confirmed that the consent screen appears properly after clicking on google drive, but now the issue is that the sign in fails… [resolved separately: OAuth-proxy CORS]. … One issue however is that I was not prompted to login with my biometric credentials, which i had saved before on the PWA. In addition, if I navigate to settings → account, under the biometric login section, I get the message: "your browser does not support biometric login (webauthn)"
+
+**[plan — /beanies-plan]**
+
+> make a plan to implement biometric login on the native app while ensuring biometric login remains clean and robust on the PWA and browser, and ensure biometric login should work seamlessly across all platforms, including android, iOS, and other relevant platforms. also please ensure that biometric login should work across both newer and older devices ensuring the necessary code paths, polyfills, etc are in place to ensure biometric login works consistently across all android and iOS devices, both newer and older.
+
+**[approval]** Plan approved via ExitPlanMode (4-pass review).
+
+**[sequencing]** Merge the OAuth branch to main first, then start biometric on a fresh branch off main.
+
+**[go]** "go ahead to merge 221 to main and then continue with plan implementation"
+
+## Outcome
+
+Root cause (two compounding): the native WebView didn't expose `window.PublicKeyCredential`
+(WebAuthn off by default in Capacitor's WebView), and `rpId = window.location.hostname`
+resolved to `localhost`, which can't match the PWA passkey RP ID (`app.beanies.family`).
+
+Fix (branch `feat/native-biometric-passkeys`, WebView-WebAuthn approach — reuse the
+existing JS passkey/PRF stack, no native plugin):
+
+1. `passkeyService.ts`: new `getRpId()` (native → fixed `WEBAUTHN_RP_ID = 'app.beanies.family'`,
+   web → `window.location.hostname` unchanged so existing passkeys aren't orphaned); replaced
+   the 3 `window.location.hostname` sites; added the service's only `reportError()` breadcrumb
+   in the `formatCredentialManagerError` fallthrough (severity warning).
+2. Reworded `passkey.unsupported` to surface-neutral copy (no "browser"); zh regenerated.
+3. Android: `androidx.webkit` dep + feature-detected `setWebAuthenticationSupport(FOR_APP)` in
+   `MainActivity` (Log.w on failure, never crash); new WebAuthn `assetlinks.json`
+   (`get_login_creds`) on the app origin; `deploy.yml` `include-hidden-files: true` (the
+   unfixed half of the ADR-029 deploy-strip bug — would have silently 404'd the assetlinks).
+4. iOS readiness: AASA with `<APPLE_TEAM_ID>` placeholder + README documenting the two-origin
+   fingerprint-sync discipline. iOS entitlement + on-device validation deferred to the iOS build.
+5. Help Center: new `security/biometric-login` article.
+
+`npm run validate` green (2591 tests, +2 getRpId). Pending greg: Vue prod deploy (so the
+assetlinks is live) + APK rebuild + on-device verification.

--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -1,0 +1,52 @@
+# `app.beanies.family` well-known files — native biometric (passkey) association
+
+These files associate the native beanies.family app with the **`app.beanies.family`**
+Relying Party so device biometrics (passkeys) registered on the PWA can be used
+inside the native WebView. Served from the Vue app's S3 bucket / CloudFront
+(`app.beanies.family`), deployed by `.github/workflows/deploy.yml`. See ADR-029
+and `docs/plans/2026-05-23-native-pwa-biometric-login.md`.
+
+> **Deploy note:** `deploy.yml` sets `include-hidden-files: true` on the
+> build-artifact upload so `dist/.well-known/` survives the artifact round-trip
+> and reaches S3 (`upload-artifact` strips dotfiles by default; `aws s3 sync`
+> itself preserves them). Without it these files 404 and association silently
+> fails. Verify after deploy:
+> `curl -sI https://app.beanies.family/.well-known/assetlinks.json` → 200, JSON.
+
+## `assetlinks.json` — Android (WebAuthn `get_login_creds`)
+
+Authorizes the Android app to assert WebAuthn credentials for RP ID
+`app.beanies.family` (RP ID is set in `src/services/auth/passkeyService.ts`
+`getRpId()`). Routed through the Android Credential Manager once the WebView
+enables WebAuthn (`MainActivity.enableWebAuthnIfSupported`).
+
+## `apple-app-site-association` — iOS (`webcredentials`)
+
+Authorizes the iOS app to use passkeys for `app.beanies.family` in WKWebView
+(iOS 16+), paired with the `webcredentials:app.beanies.family` Associated
+Domains entitlement.
+
+> **`<APPLE_TEAM_ID>` is a placeholder.** No iOS build exists yet. A placeholder
+> AASA on the live origin is harmless (iOS won't match it), but iOS biometric
+> association silently never works until the real Apple Team ID replaces the
+> placeholder when the iOS app is built. Serve with `Content-Type: application/json`
+> and **no `.json` extension** (already the filename).
+
+## ⚠️ Two assetlinks files exist — keep their fingerprints in sync
+
+There are **two** Android Digital Asset Links files on **two origins**, both for
+package `family.beanies.app`:
+
+| File | Origin | Relation | Purpose |
+| --- | --- | --- | --- |
+| `web/public/.well-known/assetlinks.json` | `beanies.family` (Astro, `deploy-web.yml`) | `handle_all_urls` | OAuth App Link (`/oauth/native`) |
+| `public/.well-known/assetlinks.json` (this dir) | `app.beanies.family` (Vue app, `deploy.yml`) | `get_login_creds` | WebAuthn / biometric |
+
+They share the **same package + SHA-256 cert fingerprint(s)**. At **every
+signing-key event** — debug keystore rotation, adding the release/upload key,
+Play App Signing re-sign, or a second native app — **both files must be updated
+together**, or native auth breaks silently on the un-updated origin (App Links on
+one, biometrics on the other). Treat the fingerprint list as one logical value
+maintained in two places. Both currently list only the **debug** fingerprint
+(`19:E4:…`); add the **release** fingerprint to **both** when the Play release
+lane (A6) is activated. Get fingerprints per `web/public/.well-known/README.md`.

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "webcredentials": {
+    "apps": ["<APPLE_TEAM_ID>.family.beanies.app"]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.get_login_creds"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "family.beanies.app",
+      "sha256_cert_fingerprints": [
+        "19:E4:E6:85:03:E2:59:C7:34:2D:BE:1E:CC:6B:9E:97:31:50:1B:D6:BA:52:7E:33:12:AF:F3:40:C0:B1:18:88"
+      ]
+    }
+  }
+]

--- a/public/translations/zh.json
+++ b/public/translations/zh.json
@@ -2,7 +2,7 @@
   "meta": {
     "language": "zh",
     "languageName": "中文 (简体)",
-    "lastUpdated": "2026-05-21",
+    "lastUpdated": "2026-05-23",
     "translationCount": 2923
   },
   "translations": {
@@ -3212,9 +3212,9 @@
       "lastUpdated": "2026-02-25"
     },
     "passkey.unsupported": {
-      "translation": "您的浏览器不支持生物识别登录(WebAuthn)。",
-      "hash": "e5z6v4",
-      "lastUpdated": "2026-02-25"
+      "translation": "生物识别解锁在此设备上不可用。使用您的密码登录。",
+      "hash": "wi17rr",
+      "lastUpdated": "2026-05-23"
     },
     "passkey.rename": {
       "translation": "重命名",

--- a/src/content/help/security.ts
+++ b/src/content/help/security.ts
@@ -259,4 +259,82 @@ export const SECURITY_ARTICLES: HelpArticle[] = [
       },
     ],
   },
+  {
+    slug: 'biometric-login',
+    category: 'security',
+    title: 'Unlock With Biometrics (Face ID, Fingerprint, Device PIN)',
+    excerpt:
+      'Sign back in with a tap using your device biometrics — in the app and the browser. A convenience layer over your family password, never a replacement.',
+    icon: '\u{1F441}️',
+    readTime: 4,
+    updatedDate: '2026-05-23',
+    sections: [
+      {
+        type: 'heading',
+        content: 'What biometric unlock does',
+        level: 2,
+        id: 'what-it-does',
+      },
+      {
+        type: 'paragraph',
+        content:
+          'Biometric unlock lets you reopen your pod with <strong>Face ID, a fingerprint, or your device PIN</strong> instead of typing your family password every time. It uses <strong>passkeys</strong> (WebAuthn) — the same passwordless standard your bank and Google use — and works in the installed app and in your browser.',
+      },
+      {
+        type: 'callout',
+        content:
+          'Biometric unlock is a convenience layer <em>over</em> your family password — not a replacement for it. Your password always works, and losing or replacing your device never locks you out of your pod. Keep your password somewhere safe.',
+        title: 'Your password is still the master key',
+        icon: '\u{1F511}',
+      },
+      {
+        type: 'heading',
+        content: 'How to turn it on',
+        level: 2,
+        id: 'turn-it-on',
+      },
+      {
+        type: 'steps',
+        content: '',
+        items: [
+          'Open <strong>Settings → Account</strong>.',
+          'Under <strong>Biometric login</strong>, tap <strong>Set up</strong> and confirm with your device biometrics.',
+          "That's it — next time you sign in on that device, you'll be offered a one-tap biometric unlock.",
+        ],
+      },
+      {
+        type: 'heading',
+        content: 'How it stays private',
+        level: 2,
+        id: 'privacy',
+      },
+      {
+        type: 'list',
+        content: '',
+        items: [
+          'Your <strong>biometrics never leave your device</strong> — Face ID / fingerprint data is handled by your phone or computer’s secure hardware, and beanies.family never sees it.',
+          'The passkey unwraps your family key <strong>on your device</strong>; beanies only ever stores the <em>wrapped</em> (encrypted) key. See <a href="/help/security/how-your-data-is-encrypted">How Your Data Is Encrypted</a>.',
+          'A passkey you create on one device can sync to your other devices on the <strong>same platform</strong> (iCloud Keychain for Apple, Google Password Manager for Android/Chrome) — but not across ecosystems.',
+        ],
+      },
+      {
+        type: 'heading',
+        content: 'Which devices support it',
+        level: 2,
+        id: 'device-support',
+      },
+      {
+        type: 'paragraph',
+        content:
+          'Biometric unlock needs a reasonably recent device: <strong>iOS 16+</strong>, a modern <strong>Android</strong> with the system passkey/credential manager, or an up-to-date desktop browser. On older devices — or any device without biometric hardware set up — beanies.family simply asks for your password instead. Nothing breaks; you just sign in the usual way.',
+      },
+      {
+        type: 'infoBox',
+        content:
+          'If a device can’t use biometrics, you’ll see a short note and the password field instead of a dead end. You can always fall back to your password on any device, anytime.',
+        title: 'No supported device? No problem',
+        icon: '\u{1F50F}',
+      },
+    ],
+  },
 ];

--- a/src/services/auth/__tests__/passkeyService.test.ts
+++ b/src/services/auth/__tests__/passkeyService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { PasskeyRegistration } from '@/types/models';
 
 // --- Mock passkeyRepository ---
@@ -39,6 +39,14 @@ vi.mock('@/services/indexeddb/repositories/globalSettingsRepository', () => ({
   getGlobalSettings: vi.fn(async () => mockGlobalSettings),
 }));
 
+// --- Mock capabilities (native seam) + errorReporter ---
+const { isNativeMock } = vi.hoisted(() => ({ isNativeMock: vi.fn(() => false) }));
+vi.mock('@/services/sync/capabilities', () => ({
+  isNative: isNativeMock,
+  getPlatform: vi.fn(() => 'web'),
+}));
+vi.mock('@/utils/errorReporter', () => ({ reportError: vi.fn() }));
+
 // Imports must come after vi.mock calls
 import {
   bufferToBase64url,
@@ -48,6 +56,7 @@ import {
   guessAuthenticatorLabel,
   authenticateWithPasskey,
   registerPasskeyForMember,
+  getRpId,
 } from '../passkeyService';
 import * as passkeyRepo from '@/services/indexeddb/repositories/passkeyRepository';
 
@@ -90,6 +99,20 @@ function makeFakeAssertion(opts: {
 }
 
 // --- Tests ---
+
+describe('getRpId — WebAuthn Relying Party ID (ADR-029)', () => {
+  afterEach(() => isNativeMock.mockReturnValue(false));
+
+  it('returns the fixed app domain on native (WebView origin is localhost; association supplies trust)', () => {
+    isNativeMock.mockReturnValue(true);
+    expect(getRpId()).toBe('app.beanies.family');
+  });
+
+  it('returns the current origin hostname on web/PWA — unchanged behavior, so existing passkeys are not orphaned', () => {
+    isNativeMock.mockReturnValue(false);
+    expect(getRpId()).toBe(window.location.hostname);
+  });
+});
 
 describe('Encoding utilities', () => {
   it('bufferToBase64url / base64urlToBuffer roundtrip preserves bytes', () => {

--- a/src/services/auth/passkeyService.ts
+++ b/src/services/auth/passkeyService.ts
@@ -21,8 +21,33 @@ import type { PasskeyRegistration, PasskeySecret } from '@/types/models';
 import { toISODateString } from '@/utils/date';
 import { getGlobalSettings } from '@/services/indexeddb/repositories/globalSettingsRepository';
 import { importFamilyKey } from '@/services/crypto/familyKeyService';
+import { isNative, getPlatform } from '@/services/sync/capabilities';
+import { reportError } from '@/utils/errorReporter';
 
 const RP_NAME = 'beanies.family';
+
+// Fixed WebAuthn Relying Party ID for native apps. The native WebView serves
+// from `https://localhost`, which is NOT a usable RP ID and doesn't match the
+// PWA's credentials — so on native we assert against the production app domain,
+// authorized by the Digital-Asset-Links (Android) / AASA (iOS) association we
+// host at `https://app.beanies.family/.well-known/`. This MUST equal the host
+// the existing PWA passkeys were registered under (`window.location.hostname`
+// on the live PWA) or those credentials would be orphaned. It is fixed product
+// infrastructure tied to the hosted association files — not a per-deploy knob,
+// and deliberately NOT sourced from `features.ts` (deployment-mode gating). See
+// ADR-029 and docs/plans/2026-05-23-native-pwa-biometric-login.md.
+const WEBAUTHN_RP_ID = 'app.beanies.family';
+
+/**
+ * Resolve the WebAuthn Relying Party ID for the current surface.
+ * - Web/PWA/dev/self-host: the current origin's hostname (unchanged behavior —
+ *   `app.beanies.family` in prod, `localhost` in dev, the self-hoster's domain).
+ * - Native (Capacitor): the fixed `WEBAUTHN_RP_ID`, since the WebView origin
+ *   (`localhost`) is not the RP ID — the platform association supplies the trust.
+ */
+export function getRpId(): string {
+  return isNative() ? WEBAUTHN_RP_ID : window.location.hostname;
+}
 
 // --- Feature detection ---
 
@@ -81,7 +106,7 @@ export async function registerPasskeyForMember(
   // Generate client-side challenge
   const challenge = crypto.getRandomValues(new Uint8Array(32));
 
-  const rpId = window.location.hostname;
+  const rpId = getRpId();
   const prfExtension = buildPRFExtension();
 
   const publicKeyOptions: PublicKeyCredentialCreationOptions = {
@@ -215,7 +240,7 @@ export async function authenticateWithPasskey(
   }
 
   const challenge = crypto.getRandomValues(new Uint8Array(32));
-  const rpId = window.location.hostname;
+  const rpId = getRpId();
   const prfExtension = buildPRFExtension();
 
   // Discoverable credential mode: omit allowCredentials entirely.
@@ -441,7 +466,7 @@ export async function signalCredentialsRemoved(credentialIds: string[]): Promise
     return;
   }
 
-  const rpId = window.location.hostname;
+  const rpId = getRpId();
   const signal = (
     PublicKeyCredential as unknown as {
       signalUnknownCredential: (opts: { rpId: string; credentialId: string }) => Promise<void>;
@@ -618,6 +643,21 @@ function formatCredentialManagerError(err: unknown): string {
       return 'A security error occurred. Please make sure you are using a secure (HTTPS) connection.';
     }
   }
+  // Unrecognized passkey failure — surface a friendly string to the user AND a
+  // developer breadcrumb (the only reportError in this service). `warning`, not
+  // `error`: the caller still falls back to password, so it's not user-blocking.
+  // Known/cancelled cases never reach here (handled upstream + de-noised,
+  // triage 2026-05-02). errorReporter's reentry-guard + 60s dedup cover floods.
+  reportError({
+    surface: 'passkey-assertion',
+    message: err instanceof Error ? err.message : 'unknown passkey error',
+    error: err,
+    severity: 'warning',
+    context: {
+      domException: err instanceof DOMException ? err.name : null,
+      platform: getPlatform(),
+    },
+  });
   return err instanceof Error
     ? err.message
     : 'An unexpected error occurred during passkey operation';

--- a/src/services/translation/uiStrings.ts
+++ b/src/services/translation/uiStrings.ts
@@ -3126,8 +3126,8 @@ const STRING_DEFS = {
     beanie: 'no biometric logins registered yet.',
   },
   'passkey.unsupported': {
-    en: 'Your browser does not support biometric login (WebAuthn).',
-    beanie: 'your browser does not support biometric login (webauthn).',
+    en: "Biometric unlock isn't available on this device. Use your password to sign in.",
+    beanie: "biometric unlock isn't available on this device. use your password to sign in.",
   },
   'passkey.rename': { en: 'Rename', beanie: 'rename' },
   'passkey.renameLabel': { en: 'Device name', beanie: 'device name' },


### PR DESCRIPTION
## Summary

Enables biometric unlock (Face ID / fingerprint / device PIN) **inside the native Capacitor app**, reusing the existing web WebAuthn/PRF/family-key stack — no native plugin, no second `navigator.credentials` path. Keeps PWA/browser biometric **unchanged** (zero regression) and falls back cleanly to password on devices that can't do passkeys.

Follow-up to the OAuth fix; same `https://localhost`-origin family (ADR-029), harder fix (WebAuthn can't be CORS-allowlisted — it needs platform association).

## Root cause (native)
1. The Android WebView didn't expose `window.PublicKeyCredential` (WebAuthn off by default in Capacitor's WebView).
2. `rpId = window.location.hostname` resolved to `localhost`, which can't match the PWA passkey's RP ID (`app.beanies.family`).

## Changes
- **`passkeyService.ts`** — `getRpId()`: native → fixed `WEBAUTHN_RP_ID = 'app.beanies.family'` (the Digital-Asset-Links / AASA association supplies trust); web → `window.location.hostname` **unchanged** so existing passkeys are **not orphaned**. Replaced the 3 rpId sites. Added the service's only `reportError()` breadcrumb in the `formatCredentialManagerError` fallthrough (`warning` — password fallback still completes).
- **i18n** — reworded `passkey.unsupported` to surface-neutral copy (no "browser"); `zh` regenerated.
- **Android** — `androidx.webkit` dep + feature-detected `setWebAuthenticationSupport(FOR_APP)` in `MainActivity` (`Log.w` on failure, never crashes); new WebAuthn `assetlinks.json` (`get_login_creds`) on the **app** origin (`app.beanies.family`).
- **deploy.yml** — `include-hidden-files: true` on `upload-artifact` so `dist/.well-known/` ships (the unfixed half of the ADR-029 deploy-strip bug — would have silently 404'd the assetlinks).
- **iOS readiness** — AASA with `<APPLE_TEAM_ID>` placeholder + `public/.well-known/README.md` documenting the two-origin fingerprint-sync discipline. iOS entitlement + on-device validation **deferred to the iOS build** (none exists yet).
- **Help Center** — new `security/biometric-login` article.

## Verification done
- `npm run validate` green: type-check + lint (0 errors) + format + **2591 tests** (+2 `getRpId`) + build.
- Web/PWA behavior unchanged (getRpId returns hostname on web); native additions are feature-detected + graceful.

## Verification still needed (greg-driven, can't be CLI-tested)
1. **Vue prod deploy** so `https://app.beanies.family/.well-known/assetlinks.json` is live (the deploy now ships `.well-known/`). Verify: `curl -sI https://app.beanies.family/.well-known/assetlinks.json` → 200.
2. **APK rebuild** from this branch (CI debug-APK lane).
3. **On-device**: Settings → enable biometric → register → sign out → biometric unlock. Capture PRF-present vs PRF-absent (Android Credential Manager PRF support is uncertain; cached-key/password fallback covers it either way).

Merging is low-risk for existing users (web unchanged; native is additive + falls back to password), but native biometric isn't *provable* until 1–3 above.

## Plan
`docs/plans/2026-05-23-native-pwa-biometric-login.md` (4-pass review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)