### PR TITLE
fix(login): show spinner during Drive listing so storage cards aren't clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ent
 
 ## 2026-05-23
 
+### Fixed
+
+- **No more clickable buttons during the "finding your pod" moment after Google sign-in.** When you return from the Google consent screen, beanies.family takes a second or two to fetch your Drive files before showing them. Previously the "Google Drive" and "local file" buttons stayed visible and tappable during that gap, which was confusing. Now you see the "counting beans…" spinner for that whole moment — on every device — until your pod files appear.
+
 ### Added
 
 - **Biometric unlock now works in the native app, not just the browser.** Face ID, fingerprint, and device-PIN sign-in (passkeys) now work inside the native Android app — using the same passkeys you set up on the website, with no re-enrollment. Under the hood the app's WebView now supports WebAuthn and is associated with `app.beanies.family` so your existing passkeys are recognized. On older devices that can't do passkeys, sign-in cleanly falls back to your password (and the app no longer shows a confusing "your browser doesn't support…" message). Biometrics never leave your device, and your family password always remains the master key. iOS support is configured and ships when the iOS app is built. (See ADR-029.)

--- a/src/components/login/LoadPodView.vue
+++ b/src/components/login/LoadPodView.vue
@@ -473,7 +473,10 @@ const showDriveEmptyState = ref(false);
 // points; this only consolidates *which one wins* so the template reads one
 // value instead of a fragile overlapping v-if chain. Precedence reproduces the
 // pre-refactor render order exactly: outer decrypt > (reconnect) > the inner
-// chain isLoadingFile → needsPermissionGrant → showDriveEmptyState → cards.
+// chain (isLoadingFile | isDriveLoading) → needsPermissionGrant → showDriveEmptyState → cards.
+// `isDriveLoading` (the Drive *listing* round-trip) shows the spinner too, so the
+// storage cards aren't left clickable during the ~2s listing — notably after the
+// OAuth redirect returns and re-opens the picker (ADR-029).
 // NOTE: `decrypt` keys off `showDecryptModal` ALONE, never `hasPendingEncryptedFile`
 // — several flows stage a pending file with the modal closed so the biometric
 // handoff can take over; deriving decrypt from the pending file would render the
@@ -488,7 +491,7 @@ const viewState = computed<
 >(() => {
   if (showDecryptModal.value) return 'decrypt';
   if (props.reconnectDriveFile && !reconnectDismissed.value) return 'reconnect';
-  if (isLoadingFile.value) return 'auto-loading';
+  if (isLoadingFile.value || isDriveLoading.value) return 'auto-loading';
   if (props.needsPermissionGrant) return 'permission-grant';
   if (showDriveEmptyState.value) return 'empty';
   return 'cards';


### PR DESCRIPTION
## Summary

Minor UX fix on the sign-in / load-pod screen. After returning from the Google consent redirect (the `?resume=load-drive` continuation), the app calls `listGoogleDriveFiles()` for ~2s before the discovered `.beanpod` files appear. During that window the "Google Drive" and "local file" storage cards stayed rendered and **clickable**, which is confusing.

## Fix

`LoadPodView`'s `viewState` only checked `isLoadingFile` (loading a *selected* file), not `isDriveLoading` (the Drive *listing* round-trip). Added `isDriveLoading` to the `'auto-loading'` branch so the existing "counting beans…" spinner covers the listing window — the cards are no longer shown/clickable mid-listing.

- Reuses the existing spinner state; no new UI.
- Applies on **every** surface — also fixes the same gap on a normal desktop "Google Drive" click, not just the native redirect-resume.
- Reported by greg on the native Android app after the OAuth fix.

## Verification

- `npm run type-check` clean; existing `LoadPodView.test.ts` (6) green (empty-state flow unaffected — the listing settles to empty/picker as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)