### PR TITLE
fix(deploy): guard against prod builds shipped without Slack/error webhooks

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -17,6 +17,9 @@ const env = import.meta.env;
 
 const ok = (v: unknown): boolean => typeof v === 'string' && v.trim().length > 0;
 
+// The canonical cloud host. Update this set if it ever changes.
+const CLOUD_HOSTS = new Set(['app.beanies.family']);
+
 export const features = {
   // Drive sync only requires VITE_GOOGLE_CLIENT_ID — that's what gates OAuth
   // and the Drive REST API. VITE_GOOGLE_API_KEY + VITE_GOOGLE_PROJECT_NUMBER
@@ -40,16 +43,50 @@ export const features = {
 
 export type FeatureKey = keyof typeof features;
 
-// A cloud-ish build (Drive and/or the family registry wired) with no error
-// webhook means `reportError()` silently no-ops — exactly the failure mode
-// that hid a real iPhone onboarding break (May 2026). Make it loud at boot so
-// a missing `VITE_BEANIES_ERROR_WEBHOOK_URL` (e.g. an unset GitHub repo
-// variable) can't masquerade as working error reporting. Production builds
-// only — dev/test don't ship that env var and that's fine.
-if (env.PROD && !features.errorReporter && (features.drive || features.registry)) {
-  console.warn(
-    '[features] errorReporter is OFF (VITE_BEANIES_ERROR_WEBHOOK_URL is unset) but this looks like a cloud build (drive/registry are configured). Errors will NOT reach #beanies-errors. Set the BEANIES_ERROR_WEBHOOK_URL repo variable.'
-  );
+// A cloud-ish build (Drive and/or the family registry wired) is the official
+// app, so it MUST also have the operational webhooks wired — otherwise the
+// notification silently no-ops: `slackPost` short-circuits on an empty URL, and
+// the client POSTs with `no-cors` so even a live-but-dead webhook can't surface
+// a failure. This exact gap hid a real iPhone onboarding break (May 2026,
+// errorReporter) and later dropped every "new family pod" Slack ping (June 2026,
+// slackPodCreate — a dev build shipped to prod with no webhook). Make it loud at
+// boot so an unset GitHub secret/variable can't masquerade as working alerting.
+// Production builds only — dev/test/self-host omit these and that's fine.
+if (env.PROD && (features.drive || features.registry)) {
+  const operationalWebhooks: ReadonlyArray<readonly [FeatureKey, string, string]> = [
+    ['errorReporter', 'VITE_BEANIES_ERROR_WEBHOOK_URL', 'Errors will NOT reach #beanies-errors'],
+    [
+      'slackPodCreate',
+      'VITE_SLACK_WEBHOOK_URL',
+      'New-family pod notifications will NOT reach Slack',
+    ],
+  ];
+  for (const [key, envVar, impact] of operationalWebhooks) {
+    if (!features[key]) {
+      console.warn(
+        `[features] ${key} is OFF (${envVar} is unset) but this looks like a cloud build ` +
+          `(drive/registry are configured). ${impact}. Set the matching GitHub secret/variable.`
+      );
+    }
+  }
+
+  // A dev/local build (no VITE_BUILD_SHA → 'dev') must never reach the canonical
+  // cloud host: it ships none of the CI-injected env (webhooks, analytics, build
+  // SHA). Detecting it here fingerprints the June 2026 incident — a manual
+  // `npm run build` synced to app.beanies.family instead of deploying through the
+  // "Deploy beanies PROD" workflow. Fix: redeploy via the workflow.
+  const buildSha = (env.VITE_BUILD_SHA as string | undefined) ?? 'dev';
+  if (
+    typeof window !== 'undefined' &&
+    CLOUD_HOSTS.has(window.location.hostname) &&
+    buildSha === 'dev'
+  ) {
+    console.error(
+      '[features] A dev/local build is live on the cloud host (VITE_BUILD_SHA is "dev"). ' +
+        'This bundle was NOT produced by the "Deploy beanies PROD" workflow, so Slack webhooks, ' +
+        'error reporting, and analytics are all disabled. Redeploy via the workflow.'
+    );
+  }
 }
 
 /**
@@ -72,9 +109,6 @@ export function canInviteFamily(): boolean {
 const ESSENTIAL: FeatureKey[] = ['drive', 'registry'];
 
 export type DeploymentMode = 'cloud' | 'self-host-full' | 'self-host-limited';
-
-// Update this set if the canonical cloud host ever changes.
-const CLOUD_HOSTS = new Set(['app.beanies.family']);
 
 export function getDeploymentMode(): DeploymentMode {
   if (CLOUD_HOSTS.has(window.location.hostname)) return 'cloud';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,43 @@ import topLevelAwait from 'vite-plugin-top-level-await';
 import { VitePWA } from 'vite-plugin-pwa';
 import { fileURLToPath, URL } from 'node:url';
 
+/**
+ * Fail an *official* production build that is missing an operational webhook.
+ *
+ * `deploy.yml` is the only build that sets VITE_BUILD_SHA (= github.sha), so its
+ * presence marks the canonical CI deploy. On such a build the Slack + error
+ * webhooks MUST be wired: without them the client notifications silently no-op
+ * (slackPost short-circuits on an empty URL; the no-cors POST can't report a
+ * failure). Local dev and self-host builds legitimately omit these, so they are
+ * skipped entirely. Runtime counterpart lives in src/config/features.ts.
+ *
+ * This complements — does not replace — deploying via the workflow: a manual
+ * `npm run build` has no VITE_BUILD_SHA, so it's caught at runtime instead (the
+ * features.ts dev-build-on-cloud-host check) rather than here.
+ */
+function assertOfficialBuildEnv() {
+  return {
+    name: 'beanies:assert-official-build-env',
+    apply: 'build' as const,
+    buildStart() {
+      if (!process.env.VITE_BUILD_SHA) return; // not the official CI build
+      const required = ['VITE_SLACK_WEBHOOK_URL', 'VITE_BEANIES_ERROR_WEBHOOK_URL'];
+      const missing = required.filter((k) => !process.env[k]?.trim());
+      if (missing.length > 0) {
+        throw new Error(
+          `[beanies] Official build is missing required env: ${missing.join(', ')}. ` +
+            'These gate operational Slack alerting — shipping without them silently drops every ' +
+            'notification. Set the matching GitHub secret/variable, then redeploy via "Deploy beanies PROD".'
+        );
+      }
+    },
+  };
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
+    assertOfficialBuildEnv(),
     wasm(),
     topLevelAwait(),
     vue(),


### PR DESCRIPTION
## Why

On 2026-05-31 a manual local `npm run build` (build_sha `dev`) was synced to `app.beanies.family` instead of deploying through the **Deploy beanies PROD** workflow. That bundle had none of the CI-injected env, so `VITE_SLACK_WEBHOOK_URL` and `VITE_BEANIES_ERROR_WEBHOOK_URL` were empty — the "new family pod" Slack ping **and** every `#beanies-errors` alert silently no-op'd (`slackPost` short-circuits on an empty URL; the no-cors client POST can't surface a failure). All GitHub secrets/variables were correct; the build simply bypassed injection.

Two free subscribers (Substack) had joined with no corresponding Slack notification — that's what surfaced it.

## What

Two complementary guards so a webhook-less build can never silently ship again:

1. **`vite.config.ts`** — a build-time plugin fails any *official* CI build (one with `VITE_BUILD_SHA` set) that is missing either operational webhook. An empty/renamed secret now fails the build instead of shipping silently. Self-host/local builds are unaffected.
2. **`src/config/features.ts`** — extends the existing boot warning to cover `slackPodCreate` (previously errorReporter-only), **plus** a `console.error` when a `dev` build is detected running on the cloud host — fingerprinting exactly this incident.

## Already live in prod

The actual prod fix shipped on 2026-06-04 via a hotfix branch (`hotfix/deploy-webhook-hardening` → run 26925129368) off the pre-AI commit `1fede3d5`, so the webhooks are already restored in production. **This PR carries the same hardening onto `main`** so future `main` deploys keep the protection.

## Merge plan

⏳ **Do not merge/deploy standalone.** Per greg: merge + deploy this **together with the next `#133` AI release**, since deploying `main` will also promote the pending AI features. Holding until then.

Verified: type-check, lint, full unit suite (2775 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)